### PR TITLE
chore: prep DESCRIPTION for CRAN submission

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,18 +1,19 @@
 Package: gdxtools
-Title: Manipulate GDX files in R
+Title: Manipulate GDX Files in R
 Type: Package
 Version: 1.1.0
-Date: 2026-05-17
+Date: 2026-05-18
 SystemRequirements: GAMS (>= 24.2.1) is only required if you call gams()
 Authors@R: c(person("Laurent", "Drouet", role=c("aut","cre"), email="ldrouet@gmail.com"),
            person("Steve","Dirkse", role=c("cph")))
 Description: Read and write GDX files (GAMS database exchange) and convert
     parameters, sets and variables to data.frames. Backed by the
     GAMS-maintained gamstransfer package; no compiled code is shipped.
-License: EPL
+License: EPL-1.0
 URL: https://github.com/lolow/gdxtools
+BugReports: https://github.com/lolow/gdxtools/issues
 Imports:
-    gamstransfer
+    gamstransfer (>= 3.0)
 Suggests:
     testthat,
     microbenchmark


### PR DESCRIPTION
## Summary

Final polish on the DESCRIPTION so that \`R CMD check --as-cran\` is clean and the package is ready for a first CRAN upload.

## Changes

- **Title case** — `"Manipulate GDX files in R"` → `"Manipulate GDX Files in R"` (CRAN policy: every significant word capitalised)
- **License** — `EPL` → `EPL-1.0`. Bare `EPL` is not in R's license DB and required a `| file LICENSE` pointer; `EPL-1.0` is a standard entry that R recognises directly, so no LICENSE file shipping is needed (LICENSE was already in `.Rbuildignore`). The redundant pointer caused a "Invalid license file pointers: LICENSE" WARNING.
- **BugReports** — add `https://github.com/lolow/gdxtools/issues` (CRAN recommendation, also auto-discovered by `usethis` / `remotes`)
- **gamstransfer version floor** — pin to `gamstransfer (>= 3.0)`. Current CRAN version is 3.0.8 and we rely on its post-2.x Container API.

## Validation

```
$ R CMD check --as-cran --no-manual gdxtools_1.1.0.tar.gz
…
Status: 1 NOTE
```

The remaining NOTE is `* checking CRAN incoming feasibility ... NOTE` → `New submission` — unavoidable on a first upload.

## Next steps after merge

- Tag and release as `v1.1.1` (or include in the next minor bump)
- Submit via https://cran.r-project.org/submit.html — CRAN's manual review on a new package takes ~1-3 days