### PR TITLE
refactor: use inherits() for symbol class checks in extract.gdx

### DIFF
--- a/R/gdx.R
+++ b/R/gdx.R
@@ -248,12 +248,10 @@ extract.gdx <- function(x, item, field = "l", addgdx = FALSE, ...) {
   rec <- sym$records
   if (is.null(rec)) rec <- data.frame()
 
-  cls <- class(sym)
-  is_var <- "Variable" %in% cls
-  is_eq  <- "Equation" %in% cls
-  is_par <- "Parameter" %in% cls
-  is_set <- ("Set" %in% cls) || (".BaseAlias" %in% cls) ||
-            ("Alias" %in% cls) || ("UniverseAlias" %in% cls)
+  is_var <- inherits(sym, "Variable")
+  is_eq  <- inherits(sym, "Equation")
+  is_par <- inherits(sym, "Parameter")
+  is_set <- inherits(sym, c("Set", ".BaseAlias", "Alias", "UniverseAlias"))
 
   field_map <- c(l = "level", m = "marginal", lo = "lower", up = "upper")
   dim <- as.integer(sym$dimension)


### PR DESCRIPTION
## Summary
- Replace the four `"X" %in% class(sym)` membership tests in `extract.gdx` with `inherits()` calls
- Drop the now-unused `cls` local

`inherits(sym, c("Set", ".BaseAlias", "Alias", "UniverseAlias"))` returns `TRUE` if any of the listed classes is present, so the set check collapses to a single call. Behavior is unchanged.

## Test plan
- [x] `Rscript -e "testthat::test_dir('tests/testthat')"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)