### PR TITLE
fix: undefined 'cls' in extract.gdx error path (CRAN NOTE)

### DIFF
--- a/R/gdx.R
+++ b/R/gdx.R
@@ -303,7 +303,7 @@ extract.gdx <- function(x, item, field = "l", addgdx = FALSE, ...) {
       df <- rec[, dom_cols, drop = FALSE]
     }
   } else {
-    stop("Unknown symbol type: ", paste(cls, collapse = "/"))
+    stop("Unknown symbol type: ", paste(class(sym), collapse = "/"))
   }
 
   for (j in seq_along(df)) if (is.factor(df[[j]])) df[[j]] <- as.character(df[[j]])


### PR DESCRIPTION
## Problem
After #18 (the `inherits()` refactor) and #19 (CRAN doc work) both landed on master, `R CMD check --as-cran` reported:

```
checking R code for possible problems ... NOTE
extract.gdx: no visible binding for global variable 'cls'
```

#18 removed the `cls <- class(sym)` local but left one `cls` reference in the final `else`-branch error message (`stop("Unknown symbol type: ", paste(cls, ...))`). No test covers the unknown-symbol-type path, so it passed CI on #18 and only surfaced on the merged master.

## Fix
Inline `class(sym)` in the error message. Behavior is unchanged for valid symbols.

## Verification
`R CMD check --as-cran`: back to **Status OK, 1 NOTE** (New submission only). Tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)