### PR TITLE
test: cover extract.gdx unknown-symbol-type error path

### DIFF
--- a/tests/testthat/test_gdx.R
+++ b/tests/testthat/test_gdx.R
@@ -423,5 +423,24 @@ test_that("write.gdx accepts +Inf upper bounds", {
   file.remove("out_inf.gdx")
 })
 
+test_that("extract.gdx errors on an unrecognized symbol type", {
+  # Every real gamstransfer symbol is a Variable / Equation / Parameter /
+  # Set / Alias, so the defensive `else` branch is unreachable through a
+  # genuine gdx. Stub a container that hands back a symbol of an unknown
+  # class to exercise it.
+  fake_sym <- structure(list(records = NULL, dimension = 0L),
+                        class = "WeirdSymbol")
+  fake_container <- structure(list(hasSymbols = function(item) TRUE),
+                              class = "fake_container")
+  assign("[.fake_container", function(x, i, ...) fake_sym, envir = globalenv())
+  on.exit(rm("[.fake_container", envir = globalenv()), add = TRUE)
+
+  g <- structure(
+    list(filename = "stub.gdx", .container = fake_container,
+         .records_container = NULL, .lazy = FALSE),
+    class = "gdx")
+  expect_error(extract(g, "foo"), "Unknown symbol type: WeirdSymbol")
+})
+
 # Cleanup
 for (f in c("out_param.gdx", "out_var.gdx")) if (file.exists(f)) file.remove(f)


### PR DESCRIPTION
## Summary
Adds a unit test for the defensive `else` branch in `extract.gdx` that raises `"Unknown symbol type: …"`.

This branch is unreachable through a genuine gdx — every gamstransfer symbol is a Variable / Equation / Parameter / Set / Alias — so the test stubs a container whose `[` returns a symbol of an unknown class.

It also acts as a regression guard for the #20 fix: the pre-fix code (`paste(cls, …)`) would raise `object 'cls' not found` rather than the documented message, so this test would fail against it.

## Verification
`testthat::test_file('tests/testthat/test_gdx.R')` → **105 PASS, 0 FAIL**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)