### PR TITLE
chore: bump version to 1.1.1 for CRAN resubmission

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: gdxtools
 Title: Manipulate 'GDX' Files
 Type: Package
-Version: 1.1.0
-Date: 2026-05-18
+Version: 1.1.1
+Date: 2026-05-22
 SystemRequirements: GAMS (>= 24.2.1) is only required if you call gams()
 Authors@R: person("Laurent", "Drouet", role=c("aut","cre"), email="ldrouet@pm.me")
 Description: Read and write 'GDX' files ('GAMS' data exchange) and convert

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,15 @@
+# gdxtools 1.1.1
+
+* CRAN resubmission. Addresses the initial review: quoted software names
+  ('GDX', 'GAMS', 'gamstransfer') in the title and description, added
+  `\value` documentation to every exported function, and replaced the
+  `\dontrun{}` examples with self-contained, executable ones.
+* `extract.gdx` now uses `inherits()` for symbol-type checks and reports
+  the offending class in its unknown-symbol-type error (previously
+  referenced an undefined variable).
+* Updated maintainer email and removed the obsolete gdxrrw copyright
+  holder now that no gdxrrw code remains.
+
 # gdxtools 1.1.0
 
 ## Lazy loading by default


### PR DESCRIPTION
## Summary
Bumps `Version: 1.1.1` and `Date: 2026-05-22` so the CRAN resubmission is unambiguously distinct from the 1.1.0 tarball already reviewed.

Adds a matching `NEWS.md` entry summarizing the changes since 1.1.0:
- CRAN review fixes (quoted software names, `\value` tags, executable examples)
- `inherits()` symbol-type refactor + fixed unknown-symbol-type error message
- Maintainer email update and removal of the obsolete gdxrrw copyright holder

## Verification
`R CMD check --as-cran` on `gdxtools_1.1.1.tar.gz`: **Status OK, 1 NOTE** (New submission only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)